### PR TITLE
fix: ream-sim -> real-sim

### DIFF
--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -474,8 +474,8 @@ DATASETS = OrderedDict(
         :dims => (677_399, 47_236),
         :ncls => 2,
     ),
-    "ream-sim" => Dict(
-        :file => "ream-sim.bz2",
+    "real-sim" => Dict(
+        :file => "real-sim.bz2",
         :type => "binary",
         :dims => (72_309, 20_958),
         :ncls => 2,


### PR DESCRIPTION
It should be `real-sim`, not `ream-sim`: https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html#real-sim