### PR TITLE
perf: improve performance of dataset loader

### DIFF
--- a/src/LIBSVMdata.jl
+++ b/src/LIBSVMdata.jl
@@ -165,30 +165,27 @@ function load_dataset(
         pgbar = verbose ? ProgressBar(lines) : lines
 
         for (j, line) in enumerate(pgbar)
-            parts = split(line, ' ', limit=2)
+            elements = split(line, " ", limit=2)
+            (length(elements) == 1) && push!(elements, "")
 
-            label = parts[1]
+            label, features = elements
             y[j] = multilabel ? parse.(Float64, split(label, ",")) : parse(Float64, label)
 
-            if length(parts) > 1
-                for feature in eachsplit(parts[2], ' ')
-                    isempty(feature) && continue
+            for feature in split(features, " ")
+                isempty(feature) && continue
 
-                    colon_pos = findfirst(':', feature)
-                    isnothing(colon_pos) && continue
+                idx, val = split(feature, ":")
+                idx = parse(Int, string(idx))
+                val = parse(Float64, string(val))
 
-                    idx = parse(Int, view(feature, 1:(colon_pos-1)))
-                    val = parse(Float64, view(feature, (colon_pos+1):length(feature)))
+                if idx == 0
+                    idx_start = 0
+                end
 
-                    if idx == 0
-                        idx_start = 0
-                    end
-
-                    if val != 0
-                        push!(rows, j)
-                        push!(cols, idx-idx_start+1)
-                        push!(vals, val)
-                    end
+                if val != 0.
+                    push!(rows, j)
+                    push!(cols, idx-idx_start+1)
+                    push!(vals, val)
                 end
             end
         end


### PR DESCRIPTION
The current approach of loading data sets is quite slow. A better idea is to build the sparse matrix using triplets instead since insertion into a sparse matrix is very slow and complexity grows with size. 

I haven't tested this carefully, so it would be nice if you could review it, but I am seeing large improvements:

```julia
# Before
julia> @time load_dataset("rcv1_train.binary", dense = false, replace = false, verbose = true)
The data rcv1_train.binary was already downloaded
Loading the dataset...
100.0%┣█████████████████████████████████████████████████████████┫ 20.2k/20.2k [02:14<00:00, 151it/s]
133.645890 seconds (24.60 M allocations: 1.298 GiB, 0.26% gc time)

# Now
julia> @time load_dataset("rcv1_train.binary", dense = false, replace = false, verbose = true)
The data rcv1_train.binary was already downloaded
Loading the dataset...
100.0%┣███████████████████████████████████████████████████████┫ 20.2k/20.2k [00:02<00:00, 10.9kit/s]
  2.160787 seconds (15.55 M allocations: 629.567 MiB, 19.03% gc time, 8.32% compilation time)
```